### PR TITLE
Update cdk to use RustFunction construct

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,54 +12,22 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/cargo-lambda/cargo-lambda
+    environment: prod
     env:
       CARGO_HOME: "/__w/ftcwa-live/ftcwa-live/.cargo"
     steps:
-        - uses: actions/checkout@v4
-        - name: Cache dependencies
-          id: cache-rust
-          uses: actions/cache@v3
-          with:
-            path: |
-                lambda/target/
-                /__w/ftcwa-live/ftcwa-live/.cargo
-            key: cargo-${{ hashFiles('lambda/Cargo.lock') }}
-            restore-keys: cargo-
-        - name: Build
-          run: cargo lambda build -r --arm64 -F lambda
-          working-directory: ./lambda
-        - name: Upload build artifacts
-          uses: actions/upload-artifact@v3
-          with:
-            name: lambda
-            path: lambda/target/lambda/ftcwa-live
-        - name: Upload CDK config
-          uses: actions/upload-artifact@v3
-          with:
-            name: cdk
-            path: |
-              bin
-              lib
-              package*.json
-              cdk.json
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment: prod
-    steps:
-    - name: "Download CDK config"
-      uses: actions/download-artifact@v3
+    - uses: actions/checkout@v4
+    - name: Cache dependencies
+      id: cache-rust
+      uses: actions/cache@v3
       with:
-        name: cdk
-    - name: "Download built Lambda"
-      uses: actions/download-artifact@v3
-      with:
-        name: lambda
-        path: lambda/target/lambda/ftcwa-live
+        path: |
+            lambda/target/
+            /__w/ftcwa-live/ftcwa-live/.cargo
+        key: cargo-${{ hashFiles('lambda/Cargo.lock') }}
+        restore-keys: cargo-
     - name: Setup Node.js environment
       uses: actions/setup-node@v4.0.0
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Cache dependencies
       id: cache-rust
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
             lambda/target/

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,8 +9,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/cargo-lambda/cargo-lambda
     env:
       CARGO_HOME: "/__w/ftcwa-live/ftcwa-live/.cargo"
     steps:
@@ -24,6 +22,19 @@ jobs:
                 /__w/ftcwa-live/ftcwa-live/.cargo
             key: cargo-${{ hashFiles('lambda/Cargo.lock') }}
             restore-keys: cargo-
+        - name: Setup Node.js environment
+          uses: actions/setup-node@v4.0.0
+          with:
+            node-version: lts/*
+            cache: "npm"
+        - name: Install dependencies
+          run: npm ci
+        - name: Configure aws credentials
+          uses: aws-actions/configure-aws-credentials@v4.0.1
+          with:
+              aws-access-key-id: ${{ secrets.AWS_READ_ONLY_ACCESS_KEY_ID }}
+              aws-secret-access-key: ${{ secrets.AWS_READ_ONLY_ACCESS_KEY_SECRET }}
+              aws-region: 'us-west-2'
         - name: Build
-          run: cargo lambda build -r --arm64 -F lambda
+          run: npm run cdk diff
           working-directory: ./lambda

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,7 +15,7 @@ jobs:
         - uses: actions/checkout@v4
         - name: Cache dependencies
           id: cache-rust
-          uses: actions/cache@v3
+          uses: actions/cache@v4
           with:
             path: |
                 lambda/target/

--- a/lib/ftcwa-live-stack.ts
+++ b/lib/ftcwa-live-stack.ts
@@ -2,16 +2,15 @@ import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { RustFunction } from 'cargo-lambda-cdk';
 
 export class FTCWALiveStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
     // create Lambda
-    const rocketFn = new lambda.Function(this, 'RocketRouterFunction', {
-        code: lambda.Code.fromAsset('./lambda/target/lambda/ftcwa-live/'),
-        handler: '.',
-        runtime: lambda.Runtime.PROVIDED_AL2,
+    const rocketFn = new RustFunction(this, 'RocketRouterFunction', {
+        manifestPath: './lambda',
         architecture: lambda.Architecture.ARM_64,
         logRetention: RetentionDays.THREE_DAYS,
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "aws-cdk-lib": "2.111.0",
+        "cargo-lambda-cdk": "^0.0.22",
         "constructs": "^10.3.0",
         "source-map-support": "^0.5.21"
       },
@@ -493,6 +494,117 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "node_modules/cargo-lambda-cdk": {
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/cargo-lambda-cdk/-/cargo-lambda-cdk-0.0.22.tgz",
+      "integrity": "sha512-lpRh4TFR03FSWw/Ji6D3ZD18mAJjeWvU8ST5UdS6RwbdSXQT/0TbEjG/ccMCpqNGtrlx+txQ8WYURgtNbnDKcw==",
+      "bundleDependencies": [
+        "js-toml"
+      ],
+      "dependencies": {
+        "js-toml": "^0.1.1"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.63.0",
+        "constructs": "^10.0.5"
+      }
+    },
+    "node_modules/cargo-lambda-cdk/node_modules/@babel/runtime-corejs3": {
+      "version": "7.23.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-js-pure": "^3.30.2",
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/cargo-lambda-cdk/node_modules/@chevrotain/cst-dts-gen": {
+      "version": "10.5.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/gast": "10.5.0",
+        "@chevrotain/types": "10.5.0",
+        "lodash": "4.17.21"
+      }
+    },
+    "node_modules/cargo-lambda-cdk/node_modules/@chevrotain/gast": {
+      "version": "10.5.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/types": "10.5.0",
+        "lodash": "4.17.21"
+      }
+    },
+    "node_modules/cargo-lambda-cdk/node_modules/@chevrotain/types": {
+      "version": "10.5.0",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/cargo-lambda-cdk/node_modules/@chevrotain/utils": {
+      "version": "10.5.0",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/cargo-lambda-cdk/node_modules/chevrotain": {
+      "version": "10.5.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/cst-dts-gen": "10.5.0",
+        "@chevrotain/gast": "10.5.0",
+        "@chevrotain/types": "10.5.0",
+        "@chevrotain/utils": "10.5.0",
+        "lodash": "4.17.21",
+        "regexp-to-ast": "0.5.0"
+      }
+    },
+    "node_modules/cargo-lambda-cdk/node_modules/core-js-pure": {
+      "version": "3.33.2",
+      "hasInstallScript": true,
+      "inBundle": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cargo-lambda-cdk/node_modules/js-toml": {
+      "version": "0.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "chevrotain": "^10.4.1",
+        "xregexp": "^5.1.1"
+      }
+    },
+    "node_modules/cargo-lambda-cdk/node_modules/lodash": {
+      "version": "4.17.21",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cargo-lambda-cdk/node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cargo-lambda-cdk/node_modules/regexp-to-ast": {
+      "version": "0.5.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cargo-lambda-cdk/node_modules/xregexp": {
+      "version": "5.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.16.5"
+      }
     },
     "node_modules/constructs": {
       "version": "10.3.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "2.111.0",
+    "cargo-lambda-cdk": "^0.0.22",
     "constructs": "^10.3.0",
     "source-map-support": "^0.5.21"
   }


### PR DESCRIPTION
Updates the CDK stack to use the RustFunction Construct from https://github.com/cargo-lambda/cargo-lambda-cdk

This marginally simplifies the creation of the Lambda Function in the CDK (as the Rust-specific quirks are abstracted away in the Construct), and will automatically deal with building. Thus, removing the extra setup in the GitHub Workflows to build using a specific Docker container for cargo-lambda.